### PR TITLE
[FIX] bug fix for get_team_roster

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,1 @@
 include jockbot_nhl/config.json
-include jockbot_nhl/players.json

--- a/jockbot_nhl/nhl.py
+++ b/jockbot_nhl/nhl.py
@@ -81,7 +81,7 @@ class NHL:
         """Get team roster. Return list of player objects"""
         team_id = _team_id(team_name) if not team_id else team_id
         season = self.current_season if not season else season
-        endpoint = f"teams/{team_id}/roster"
+        endpoint = f"teams/{team_id}/roster?season={season}"
         data = _api_request(endpoint)
         player_list = data['roster']
         return player_list

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='jockbot_nhl',
-      version='0.0.9',
+      version='0.0.10',
       description='Retrieve info from NHL API',
       url='http://github.com/jalgraves/jockbot_nhl',
       author='Jonny Graves',


### PR DESCRIPTION
Used '&' instead of '?' in endpoint string causing 404 errors from API