### PR TITLE
[FIX]: NHLTeam division, conference, and overall ranks

### DIFF
--- a/jockbot_nhl/nhl.py
+++ b/jockbot_nhl/nhl.py
@@ -46,7 +46,7 @@ class NHL:
     standings = _standings()
     league_standings = _fetch_standings(standings, 'league')
     conference_standings = _fetch_standings(standings, 'conference')
-    divison_standings = _fetch_standings(standings, 'division')
+    division_standings = _fetch_standings(standings, 'division')
     wildcard_standings = {
         'Eastern': _wild_card_standings('eastern'),
         'Western': _wild_card_standings('western')
@@ -197,6 +197,8 @@ class NHLTeam(NHL):
         self.info = self.get_team_info(team_id=self.id)
         self.name = self.info['name']
         self.venue = self.info['venue']['name']
+        self.conference = self.info['conference']['name']
+        self.division = self.info['division']['name']
         self.stats = self.get_team_stats(self.id)
         self.roster = self.get_team_roster(self.id)
         self.schedule = _parse_schedule(self.get_team_schedule(team_id=self.id))
@@ -207,9 +209,9 @@ class NHLTeam(NHL):
         self.otl = self.record['record']['ot']
         self.games_played = self.record['games_played']
         self.points = self.record['points']
-        self.division_rank = None
-        self.conference_rank = None
-        self.overall_rank = None
+        self.division_rank = self.division_standings[self.division][self.name]
+        self.conference_rank = self.conference_standings[self.conference][self.name]
+        self.overall_rank = self.league_standings.get(self.name)
         self.year_by_year_records = None
 
     def __repr__(self):

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='jockbot_nhl',
-      version='0.0.11',
+      version='0.0.12',
       description='Retrieve info from NHL API',
       url='http://github.com/jalgraves/jockbot_nhl',
       author='Jonny Graves',

--- a/test/test_jockbot_nhl.py
+++ b/test/test_jockbot_nhl.py
@@ -161,6 +161,19 @@ class TestNHL(unittest.TestCase):
         team_ids = _helpers._player_ids_by_team(self.team_city)
         self.assertTrue(isinstance(team_ids, dict), 'No team player IDs')
 
+    def test_team_ranks(self):
+        overall_rank = self.team.overall_rank
+        conference_rank = self.team.conference_rank
+        division_rank = self.team.division_rank
+        # TODO update this test to not break in off season
+        self.assertIsNotNone(overall_rank, 'Overall rank is empty')
+        self.assertIsNotNone(conference_rank, 'Conference rank is empty')
+        self.assertIsNotNone(division_rank, 'Division rank is empty')
+
+    def test_team_info(self):
+        self.assertEqual(self.team.division, 'Atlantic')
+        self.assertEqual(self.team.conference, 'Eastern')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fix for the NHLTeam() attributes division_rank, conference_rank, and overall_rank to longer return None during the season.